### PR TITLE
fix: gpt api 전반적인 수정 및 사용자 맞춤 질문 리스트 반환 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
@@ -62,6 +65,7 @@ dependencies {
 
 	// OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'io.github.openfeign:feign-jackson:12.3'
 }
 
 dependencyManagement {

--- a/src/main/java/com/example/Namanba/Interview/adaptor/CustomQuestionAdaptor.java
+++ b/src/main/java/com/example/Namanba/Interview/adaptor/CustomQuestionAdaptor.java
@@ -3,6 +3,8 @@ package com.example.Namanba.Interview.adaptor;
 import com.example.Namanba.Interview.entity.CustomQuestion;
 import com.example.Namanba.Interview.repository.CustomQuestionRepository;
 import com.example.Namanba.common.annotation.Adaptor;
+import com.example.Namanba.common.exception.base.BaseException;
+import com.example.Namanba.portfolio.exception.PortfolioErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @Adaptor
@@ -12,5 +14,10 @@ public class CustomQuestionAdaptor {
 
     public CustomQuestion save(CustomQuestion customQuestion) {
         return customQuestionRepository.save(customQuestion);
+    }
+
+    public CustomQuestion findByInterviewId(Long interviewId){
+        return customQuestionRepository.findByInterviewId(interviewId)
+                .orElseThrow(() -> new BaseException(PortfolioErrorCode.PORTFOLIO_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/Namanba/Interview/adaptor/InterviewAdaptor.java
+++ b/src/main/java/com/example/Namanba/Interview/adaptor/InterviewAdaptor.java
@@ -23,5 +23,4 @@ public class InterviewAdaptor {
         return interviewRepository.save(interview);
     }
 
-
 }

--- a/src/main/java/com/example/Namanba/Interview/controller/InterviewController.java
+++ b/src/main/java/com/example/Namanba/Interview/controller/InterviewController.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/interview")
@@ -21,6 +23,11 @@ public class InterviewController {
     public SuccessResponse<InterviewDto> getQuestions(@RequestParam String interviewTitle, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
         return SuccessResponse.of(interviewService.execute(interviewTitle, user));
+    }
+
+    @GetMapping("/custom")
+    public SuccessResponse<List<String>> getCustoms(@RequestParam Long interviewId){
+        return SuccessResponse.of(interviewService.ShowcustomQuestions(interviewId));
     }
 
 }

--- a/src/main/java/com/example/Namanba/Interview/converter/InterviewConverter.java
+++ b/src/main/java/com/example/Namanba/Interview/converter/InterviewConverter.java
@@ -30,8 +30,9 @@ public class InterviewConverter {
                 .build();
     }
 
-    public static InterviewDto toInterviewDto(Interview interview, String customQuestions){
+    public static InterviewDto toInterviewDto(Interview interview, List<String> customQuestions){
         return InterviewDto.builder()
+                .interviewId(interview.getInterviewId())
                 .interviewTitle(interview.getInterviewTitle())
                 .basicInterview1(interview.getBasicInterview1())
                 .basicInterview2(interview.getBasicInterview2())

--- a/src/main/java/com/example/Namanba/Interview/converter/PromptConverter.java
+++ b/src/main/java/com/example/Namanba/Interview/converter/PromptConverter.java
@@ -34,6 +34,7 @@ public class PromptConverter {
                 userMessage.append(resume.getQuestion()).append("\n");
                 userMessage.append("[Answer] ");
                 userMessage.append(resume.getAnswer()).append("\n");
+                userMessage.append("Generate 5 questions based on the above criteria. Respond in Korean and only provide questions without any additional explanation.");
             }
         }
 

--- a/src/main/java/com/example/Namanba/Interview/dto/InterviewDto.java
+++ b/src/main/java/com/example/Namanba/Interview/dto/InterviewDto.java
@@ -8,9 +8,10 @@ import java.util.List;
 @Getter
 @Builder
 public class InterviewDto {
+    private Long interviewId;
     private String interviewTitle;
     private String basicInterview1;
     private String basicInterview2;
     private String basicInterview3;
-    private String customQuestions;
+    private List<String> customQuestions;
 }

--- a/src/main/java/com/example/Namanba/Interview/entity/CustomQuestion.java
+++ b/src/main/java/com/example/Namanba/Interview/entity/CustomQuestion.java
@@ -1,14 +1,12 @@
 package com.example.Namanba.Interview.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 @AllArgsConstructor
 @Table(name = "custom_question")
 public class CustomQuestion {
@@ -18,7 +16,8 @@ public class CustomQuestion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long customQuestionId;
 
-
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String customQuestions;
 
     @OneToOne

--- a/src/main/java/com/example/Namanba/Interview/repository/CustomQuestionRepository.java
+++ b/src/main/java/com/example/Namanba/Interview/repository/CustomQuestionRepository.java
@@ -3,5 +3,8 @@ package com.example.Namanba.Interview.repository;
 import com.example.Namanba.Interview.entity.CustomQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CustomQuestionRepository extends JpaRepository<CustomQuestion, Long> {
+    Optional<CustomQuestion> findByInterviewId(Long interviewId);
 }

--- a/src/main/java/com/example/Namanba/Interview/repository/InterviewRepository.java
+++ b/src/main/java/com/example/Namanba/Interview/repository/InterviewRepository.java
@@ -4,4 +4,5 @@ import com.example.Namanba.Interview.entity.Interview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
+
 }

--- a/src/main/java/com/example/Namanba/Interview/service/InterviewService.java
+++ b/src/main/java/com/example/Namanba/Interview/service/InterviewService.java
@@ -6,6 +6,7 @@ import com.example.Namanba.Interview.adaptor.InterviewAdaptor;
 import com.example.Namanba.Interview.converter.InterviewConverter;
 import com.example.Namanba.Interview.dto.InterviewDto;
 import com.example.Namanba.Interview.entity.BasicQuestion;
+import com.example.Namanba.Interview.entity.CustomQuestion;
 import com.example.Namanba.Interview.entity.Interview;
 import com.example.Namanba.Interview.service.processor.GenerateCustomQuestionsProcessor;
 import com.example.Namanba.portfolio.adaptor.PortfolioAdaptor;
@@ -16,6 +17,7 @@ import com.example.Namanba.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,10 +39,32 @@ public class InterviewService {
         Interview interview = setupInterviewBase(portfolio, interviewTitle);
         String customQuestions = generateCustomQuestionsProcessor.generateCustomQuestions(portfolio);
         customQuestionAdaptor.save(InterviewConverter.toCustomQuestion(interview, customQuestions));
-        return InterviewConverter.toInterviewDto(interview, customQuestions);
+        List<String> customQuestionList = extractQuestions(customQuestions);
+
+        return InterviewConverter.toInterviewDto(interview, customQuestionList);
     }
 
+    public List<String> ShowcustomQuestions(Long interviewId){
+        CustomQuestion customQuestion = customQuestionAdaptor.findByInterviewId(interviewId);
+        List<String> questions = extractQuestions(customQuestion.getCustomQuestions());
+        return questions;
+    }
 
+    private List<String> extractQuestions(String message) {
+        List<String> questions = new ArrayList<>();
+
+        // 정규식을 이용해 숫자를 기준으로 질문을 나눔
+        String[] splitQuestions = message.split("\\d+\\.\\s*");
+
+        // 첫 번째 질문이 없을 수 있으므로 빈 문자열이 아닌 경우만 처리
+        for (String question : splitQuestions) {
+            if (!question.trim().isEmpty()) {
+                questions.add(question.trim()); // 공백을 제거하고 리스트에 추가
+            }
+        }
+
+        return questions;
+    }
     private Interview setupInterviewBase(Portfolio portfolio, String interviewTitle) {
         List<String> basicQuestionList = getBasicQuestionsByRandom(portfolio.getPosition().getPositionName());
         Interview interview = InterviewConverter.toInterview(portfolio, interviewTitle, basicQuestionList);

--- a/src/main/java/com/example/Namanba/Interview/service/processor/GenerateCustomQuestionsProcessor.java
+++ b/src/main/java/com/example/Namanba/Interview/service/processor/GenerateCustomQuestionsProcessor.java
@@ -3,6 +3,7 @@ package com.example.Namanba.Interview.service.processor;
 import com.example.Namanba.Interview.converter.PromptConverter;
 import com.example.Namanba.Interview.dto.PromptContent;
 import com.example.Namanba.common.annotation.Processor;
+import com.example.Namanba.common.feign.dto.ChatResponse;
 import com.example.Namanba.common.gpt.GptProcessor;
 import com.example.Namanba.portfolio.converter.PortfolioConverter;
 import com.example.Namanba.portfolio.dto.PortfolioResponseDto;
@@ -20,8 +21,15 @@ public class GenerateCustomQuestionsProcessor {
     public String generateCustomQuestions(Portfolio portfolio) {
         PortfolioResponseDto portfolioAttributes = portfolioConverter.toPortfolioResponse(portfolio);
         PromptContent promptContent = promptConverter.toPromptContent(portfolioAttributes);
-        return gptProcessor.callChatGpt(promptContent).getMessage().getContent();
+        // ChatResponse에서 첫 번째 선택지의 메시지를 가져옵니다.
+        ChatResponse chatResponse = gptProcessor.callChatGpt(promptContent);
+        ChatResponse.Choice.Message firstChoiceMessage = chatResponse.getFirstChoiceMessage();
+
+        // 메시지가 null이 아닌지 확인하고 내용을 반환합니다.
+        if (firstChoiceMessage != null) {
+            return firstChoiceMessage.getContent();
+        } else {
+            throw new RuntimeException("First choice message is null.");
+        }
     }
-
-
 }

--- a/src/main/java/com/example/Namanba/common/feign/GptApi.java
+++ b/src/main/java/com/example/Namanba/common/feign/GptApi.java
@@ -12,9 +12,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
         url = "https://api.openai.com/v1"
 )
 public interface GptApi {
-    @PostMapping("/chat/completions")
+    @PostMapping(value = "/chat/completions", consumes = "application/json")
     ChatResponse callChatGpt(
             @RequestHeader("Authorization") String authHeader,
-            @RequestHeader("Content-Type") String contentType,
             @RequestBody ChatRequest requestBody);
 }

--- a/src/main/java/com/example/Namanba/common/feign/dto/ChatResponse.java
+++ b/src/main/java/com/example/Namanba/common/feign/dto/ChatResponse.java
@@ -2,16 +2,35 @@ package com.example.Namanba.common.feign.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ChatResponse {
-    private Message message;
+    private List<Choice> choices;
 
     @Data
+    @NoArgsConstructor
     @AllArgsConstructor
-    public static class Message {
-        private String role;
-        private String content;
+    public static class Choice {
+        private Message message;
+
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Message {
+            private String role;
+            private String content;
+        }
+    }
+
+    public Choice.Message getFirstChoiceMessage() {
+        if (choices != null && !choices.isEmpty()) {
+            return choices.get(0).getMessage();
+        }
+        return null; // 혹은 예외를 던질 수도 있음
     }
 }

--- a/src/main/java/com/example/Namanba/common/gpt/GptProcessor.java
+++ b/src/main/java/com/example/Namanba/common/gpt/GptProcessor.java
@@ -22,16 +22,31 @@ public class GptProcessor {
     private String gptModel;
 
     private final GptApi gptApi;
-
-    public ChatResponse callChatGpt(PromptContent promptContent){
+    public ChatResponse callChatGpt(PromptContent promptContent) {
         ChatRequest requestBody = new ChatRequest(
                 gptModel,
                 List.of(
-                        new ChatRequest.Message("system",promptContent.getSystemMessage()),
+                        new ChatRequest.Message("system", promptContent.getSystemMessage()),
                         new ChatRequest.Message("user", promptContent.getUserMessage())
                 )
         );
 
-        return gptApi.callChatGpt("Bearer " + apiKey, "application/json", requestBody);
+        // API 호출
+        ChatResponse response = gptApi.callChatGpt("Bearer " + apiKey, requestBody);
+
+        // 응답 출력
+        if (response != null) {
+            ChatResponse.Choice.Message firstChoiceMessage = response.getFirstChoiceMessage(); // 수정된 부분
+            if (firstChoiceMessage != null) {
+                System.out.println("Role: " + firstChoiceMessage.getRole());
+                System.out.println("Content: " + firstChoiceMessage.getContent());
+            } else {
+                System.out.println("First choice message is null.");
+            }
+        } else {
+            System.out.println("Response is null.");
+        }
+
+        return response;
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 업데이트

## 이슈 번호
resolved #14

### PR 요약 
- 프론트 테스트를 위한 [사용자 맞춤 질문] 리스트만 가져올 수 있는 /custom API 구현
- 프론트에게 제공하는 기존 interviewDto에서 interviewId를 추가
- GPT 응답 처리 오류 수정

### 변경 사항
- interviewDto: interviewId 추가, customQuestions의 반환형이 String에서 List<String>으로 변환하였습니다.
- 기존 프롬프트에서 답변 형식을 정의하는 문장을 추가했습니다.
- CustomQuestion 엔티티: customQuestions의 column에 @Lob 어노테이션과 columnDefinition = "TEXT" 을 추가하여 대용량 텍스트 저장 가능하도록 설정
- GPT 응답에서 Choice 필드가 없어 발생한 에러 수정하였습니다.
- GPT 응답에서 첫번째 Choice 메시지 가져오는 로직 추가하였습니다.