### PR TITLE
fix: 포트폴리오 API Swagger 설명 추가 및 Position 속성 수정 작업

### DIFF
--- a/src/main/java/com/example/Namanba/portfolio/controller/AwardController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/AwardController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.AwardService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,13 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/awards")
+@Tag(name = "6. [포트폴리오] 수상 내역 API", description = "수상내역 CRUD API 입니다.")
 public class AwardController {
 
     private final AwardService awardService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
-
+    @Operation(summary = "수상 내역을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createAward(@RequestBody List<AwardDto> awardDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,7 +33,7 @@ public class AwardController {
         awardService.createAwards(portfolio,awardDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "수상 내역을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateAward(@RequestBody List<AwardDto> awardDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,7 +41,7 @@ public class AwardController {
         awardService.updateAwards(portfolio,awardDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "수상 내역을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteAwards(@RequestBody List<Long> awardIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/CareerController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/CareerController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.CareerService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/careers")
+@Tag(name = "4. [포트폴리오] 경력사항 API", description = "경력사항 CRUD API 입니다.")
 public class CareerController {
 
     private final CareerService careerService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "경력사항을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createCareer(@RequestBody List<CareerDto> careerDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -29,7 +33,7 @@ public class CareerController {
         careerService.createCareers(portfolio, careerDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "경력사항을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateCareer(@RequestBody List<CareerDto> careerDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -37,7 +41,7 @@ public class CareerController {
         careerService.updateCareers(portfolio, careerDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "경력사항을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteCareers(@RequestBody List<Long> careerIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/CertificationController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/CertificationController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.CertificationService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/certifications")
+@Tag(name = "7. [포트폴리오] 자격증 API", description = "자격증 CRUD API 입니다.")
 public class CertificationController {
 
     private final CertificationService certificationService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "자격증을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createCertification(@RequestBody List<CertificationDto> certificationDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,6 +34,7 @@ public class CertificationController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "자격증을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateCertification(@RequestBody List<CertificationDto> certificationDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,6 +43,7 @@ public class CertificationController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "자격증을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteCertifications(@RequestBody List<Long> certificationIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/GPAController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/GPAController.java
@@ -7,21 +7,24 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.GPAService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/gpas")
+@Tag(name = "3. [포트폴리오] 학점 API", description = "학점 CRUD API 입니다.")
 public class GPAController {
 
     private final GPAService gpaService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "학점을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createGPA(@RequestBody List<GPADto> gpaDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,6 +33,7 @@ public class GPAController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "학점을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateGPA(@RequestBody List<GPADto> gpaDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,6 +42,7 @@ public class GPAController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "학점을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteGPAs(@RequestBody List<Long> gpaIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/LanguageCertController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/LanguageCertController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.LanguageCertService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/language-certs")
+@Tag(name = "8. [포트폴리오] 어학 자격증 API", description = "어학 자격증 CRUD API 입니다.")
 public class LanguageCertController {
 
     private final LanguageCertService languageCertService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "어학 자격증을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createLanguageCert(@RequestBody List<LanguageCertDto> languageCertDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,6 +34,7 @@ public class LanguageCertController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "어학 자격증을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateLanguageCert(@RequestBody List<LanguageCertDto> languageCertDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,6 +43,7 @@ public class LanguageCertController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "어학 자격증을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteLanguageCert(@RequestBody List<Long> languageCertsIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/MajorController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/MajorController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.MajorService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/majors")
+@Tag(name = "2. [포트폴리오] 전공 API", description = "전공 CRUD API 입니다.")
 public class MajorController {
 
     private final MajorService majorService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
-
+    @Operation(summary = "전공을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createMajor(@RequestBody List<MajorDto> majorDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -29,7 +32,7 @@ public class MajorController {
         majorService.createMajors(portfolio, majorDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "전공을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateMajor(@RequestBody List<MajorDto> majorDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -37,7 +40,7 @@ public class MajorController {
         majorService.updateMajors(portfolio, majorDtos);
         return SuccessResponse.empty();
     }
-
+    @Operation(summary = "전공을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteMajors(@RequestBody List<Long> majorIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/PortfolioController.java
@@ -8,6 +8,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.PortfolioService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -15,20 +17,20 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/portfolio")
+@Tag(name = "1. 포트폴리오 API", description = "포트폴리오 API 입니다.")
 public class PortfolioController {
 
     private final PortfolioService portfolioService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "사용자의 포트폴리오를 조회하는 API입니다.")
     @GetMapping
     public SuccessResponse<PortfolioResponseDto> getPortfolio(HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
-//        if (portfolioService.getPortfolio(user) == null) {
-//            return SuccessResponse.empty();
-//        }
         return SuccessResponse.of(portfolioService.getPortfolio(user));
     }
+    @Operation(summary = "사용자가 지원하는 직군을 입력받는 API입니다.")
     @PutMapping("/position")
     public SuccessResponse<Void> updatePositionName(@RequestParam String positionName, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/ResumeController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/ResumeController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.ResumeService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/resumes")
+@Tag(name = "9. [포트폴리오] 자기소개서 API", description = "자기소개서 CRUD API 입니다.")
 public class ResumeController {
 
     private final ResumeService resumeService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "자기소개서를 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createResume(@RequestBody List<ResumeDto> resumeDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,6 +34,7 @@ public class ResumeController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "자기소개서를 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateResume(@RequestBody List<ResumeDto> resumeDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,6 +43,7 @@ public class ResumeController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "자기소개서를 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteResumes(@RequestBody List<Long> resumeIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/controller/StackController.java
+++ b/src/main/java/com/example/Namanba/portfolio/controller/StackController.java
@@ -7,6 +7,8 @@ import com.example.Namanba.portfolio.entity.Portfolio;
 import com.example.Namanba.portfolio.repository.PortfolioRepository;
 import com.example.Namanba.portfolio.service.StackService;
 import com.example.Namanba.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/stacks")
+@Tag(name = "5. [포트폴리오] 기술 스택 API", description = "기술 스택 CRUD API 입니다.")
 public class StackController {
 
     private final StackService stackService;
     private final JwtUtil jwtUtil;
     private final PortfolioRepository portfolioRepository;
 
+    @Operation(summary = "기술 스택을 저장하는 API입니다.")
     @PostMapping
     public SuccessResponse<Void> createStack(@RequestBody List<StackDto> stackDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -30,6 +34,7 @@ public class StackController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "기술 스택을 업데이트/수정하는 API입니다.")
     @PutMapping
     public SuccessResponse<Void> updateStack(@RequestBody List<StackDto> stackDtos, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);
@@ -38,6 +43,7 @@ public class StackController {
         return SuccessResponse.empty();
     }
 
+    @Operation(summary = "기술 스택을 삭제하는 API입니다.")
     @DeleteMapping
     public SuccessResponse<Void> deleteStacks(@RequestBody List<Long> stackIds, HttpServletRequest httpRequest) {
         User user = jwtUtil.getUserByToken(httpRequest);

--- a/src/main/java/com/example/Namanba/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/Portfolio.java
@@ -24,7 +24,7 @@ public class Portfolio {
     @JoinColumn(name = "user_id")  // unique 속성 제거
     private User user;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "position_id", nullable = true, unique = false)  // unique 속성 제거
     private Position position;
 

--- a/src/main/java/com/example/Namanba/portfolio/entity/Resume.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/Resume.java
@@ -18,10 +18,14 @@ public class Resume {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long resumeId;
 
+    @Column(name = "question_num", nullable = false)
     private int questionNum;
 
+    @Column(name = "question", nullable = false)
     private String question;
 
+
+    @Column(name = "answer", nullable = false)
     private String answer;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/Award.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/Award.java
@@ -19,10 +19,10 @@ public class Award {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long awardId;
 
-    @Column(name = "type")
+    @Column(name = "type", nullable = false)
     private String awardType;
 
-    @Column(name = "prize")
+    @Column(name = "prize", nullable = false)
     private String awardPrize;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/Career.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/Career.java
@@ -21,18 +21,18 @@ public class Career {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long careerId;
 
-    @Column(name = "type")
+    @Column(name = "type", nullable = false)
     private String careerType;
 
-    @Column(name = "content")
+    @Column(name = "content", nullable = false)
     private String content;
 
     // YYYY-MM-DD 형식
-    @Column(name = "start_date")
+    @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
     // YYYY-MM-DD 형식
-    @Column(name = "end_date")
+    @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/Certification.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/Certification.java
@@ -21,10 +21,10 @@ public class Certification {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long certId;
 
-    @Column(name = "type")
+    @Column(name = "type", nullable = false)
     private String certType;
 
-    @Column(name = "date")
+    @Column(name = "date", nullable = false)
     private LocalDate certDate;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/GPA.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/GPA.java
@@ -19,10 +19,10 @@ public class GPA {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long gpaId;
 
-    @Column(name = "score")
+    @Column(name = "score", nullable = false)
     private String score;
 
-    @Column(name = "total")
+    @Column(name = "total", nullable = false)
     private String total;
 
     @OneToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/LanguageCert.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/LanguageCert.java
@@ -21,13 +21,13 @@ public class LanguageCert {
     @Column(name = "languagecert_id")
     private Long languageCertId;
 
-    @Column(name = "type")
+    @Column(name = "type", nullable = false)
     private String languageCertType;
 
-    @Column(name = "level")
+    @Column(name = "level", nullable = false)
     private String languageCertLevel;
 
-    @Column(name = "date")
+    @Column(name = "date", nullable = false)
     private LocalDate languageCertDate;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/Major.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/Major.java
@@ -15,11 +15,11 @@ import lombok.NoArgsConstructor;
 public class Major {
 
     @Id
-    @Column(name="major_id")
+    @Column(name="major_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long majorId;
 
-    @Column(name = "majorname")
+    @Column(name = "majorname", nullable = false)
     private String majorName;
 
     @ManyToOne

--- a/src/main/java/com/example/Namanba/portfolio/entity/subitems/Stack.java
+++ b/src/main/java/com/example/Namanba/portfolio/entity/subitems/Stack.java
@@ -19,10 +19,10 @@ public class Stack {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long stackId;
 
-    @Column(name = "language")
+    @Column(name = "language", nullable = false)
     private String stackLanguage;
 
-    @Column(name = "level")
+    @Column(name = "level", nullable = false)
     private String stackLevel;
 
     @ManyToOne


### PR DESCRIPTION
# PR

## PR 요약
- 포트폴리오의 세부 속성 저장 및 업데이트 요청 시, 세부 속성의 모든 필드가 있어야 저장되도록 nullable = false 제약을 추가했습니다.
- 포트폴리오 API에 스웨거 설명을 추가했습니다.
- 포트폴리오과 Position과의 관계를 일대일에서 다대일로 변경했습니다.

## 변경된 점
- 위와 동일합니다.

## 이슈 번호
resolved #58
